### PR TITLE
Disable authentication handling in portrait upload and deletion

### DIFF
--- a/app/adapters/routing/fastapi/routers/bucket_router.py
+++ b/app/adapters/routing/fastapi/routers/bucket_router.py
@@ -38,7 +38,7 @@ async def upload_portrait(
     file: UploadFile = File(..., description="Profile picture (PNG)"),
     user_id: str = Form(..., description="User ID"),
     handler: UploadPortraitHandler = Depends(get_upload_portrait_handler),
-    _=Depends(RequireRoles(["common_user", "admin"], [])),
+    # _=Depends(RequireRoles(["common_user", "admin"], [])),  # PARA REVERTIR: eliminar esta línea
 ) -> Any:
     content = await file.read()
     return await handler.execute(
@@ -55,7 +55,7 @@ async def upload_portrait(
 async def delete_portrait(
     user_id: str = Path(..., description="User ID"),
     handler: DeletePortraitHandler = Depends(get_delete_portrait_handler),
-    _=Depends(RequireRoles(["common_user", "admin"], [])),
+    # _=Depends(RequireRoles(["common_user", "admin"], [])),  # PARA REVERTIR: eliminar esta línea
 ) -> Any:
     return await handler.execute(DeletePortraitDTO(user_id=user_id))
 

--- a/app/core/use_case/bucket/delete_portrait.py
+++ b/app/core/use_case/bucket/delete_portrait.py
@@ -1,9 +1,9 @@
-from app.domain.exceptions.base_exceptions import DomainException
-from app.domain.exceptions.error_codes import USER_UNAUTHORIZED
+# from app.domain.exceptions.base_exceptions import DomainException  # PARA REVERTIR: descomentar si se habilita autenticación
+# from app.domain.exceptions.error_codes import USER_UNAUTHORIZED  # PARA REVERTIR: descomentar si se habilita autenticación
 from app.ports.driving.storage_bucket_interfaz import StorageBucketInterfaceABC
 from app.ports.driving.handler_interface import HandlerInterface
 from app.domain.dtos.bucket_dto import DeletePortraitDTO
-from app.adapters.routing.utils.context import user_context
+# from app.adapters.routing.utils.context import user_context  # PARA REVERTIR: descomentar si se habilita autenticación
 
 
 class DeletePortraitHandler(HandlerInterface):
@@ -11,15 +11,14 @@ class DeletePortraitHandler(HandlerInterface):
         self._storage = storage
     
     async def execute(self, dto: DeletePortraitDTO) -> dict:
-        user = user_context.get()
-
-        if not user or not user.id:
-            raise DomainException("Authentication required", USER_UNAUTHORIZED)
-
-        if not user.id == int(dto.user_id):
-            raise DomainException(
-                "Unauthorized to upload portrait for this user", USER_UNAUTHORIZED
-            )
+        # user = user_context.get()
+        # if not user or not user.id:
+        #     raise DomainException("Authentication required", USER_UNAUTHORIZED)
+        # if not user.id == int(dto.user_id):
+        #     raise DomainException(
+        #         "Unauthorized to upload portrait for this user", USER_UNAUTHORIZED
+        #     )
+        # PARA REVERTIR: descomentar autenticación y agregar imports de nuevo
 
         path = f"portrait/user_{dto.user_id}.png"
         

--- a/app/core/use_case/bucket/upload_portrait.py
+++ b/app/core/use_case/bucket/upload_portrait.py
@@ -1,14 +1,14 @@
-from app.domain.exceptions.error_codes import USER_UNAUTHORIZED
+# from app.domain.exceptions.error_codes import USER_UNAUTHORIZED  # PARA REVERTIR: descomentar si se habilita autenticación
 from app.ports.driving.storage_bucket_interfaz import StorageBucketInterfaceABC
 from app.ports.driving.handler_interface import HandlerInterface
 from app.domain.dtos.bucket_dto import UploadPortraitDTO
 from app.domain.exceptions.base_exceptions import (
-    DomainException,
+    # DomainException,  # PARA REVERTIR: descomentar si se habilita autenticación
     InvalidFileTypeError,
     FileSizeExceededError,
 )
 from io import BytesIO
-from app.adapters.routing.utils.context import user_context
+# from app.adapters.routing.utils.context import user_context  # PARA REVERTIR: descomentar si se habilita autenticación
 
 
 class UploadPortraitHandler(HandlerInterface):
@@ -21,15 +21,14 @@ class UploadPortraitHandler(HandlerInterface):
         self._storage = storage
 
     async def execute(self, dto: UploadPortraitDTO) -> dict:
-        user = user_context.get()
-
-        if not user or not user.id:
-            raise DomainException("Authentication required", USER_UNAUTHORIZED)
-
-        if not user.id == int(dto.user_id):
-            raise DomainException(
-                "Unauthorized to upload portrait for this user", USER_UNAUTHORIZED
-            )
+        # user = user_context.get()
+        # if not user or not user.id:
+        #     raise DomainException("Authentication required", USER_UNAUTHORIZED)
+        # if not user.id == int(dto.user_id):
+        #     raise DomainException(
+        #         "Unauthorized to upload portrait for this user", USER_UNAUTHORIZED
+        #     )
+        # PARA REVERTIR: descomentar autenticación y agregar imports de nuevo
 
         if dto.content_type != "image/png":
             raise InvalidFileTypeError(

--- a/app/domain/dtos/team_dto.py
+++ b/app/domain/dtos/team_dto.py
@@ -187,6 +187,11 @@ class ListTeamsDisplayResponseDTO(BaseModel):
     teams: list[TeamListItemDisplayDTO] = Field(default_factory=list)
 
 
+class ListTeamsTableResponseDTO(BaseModel):
+    message: str = Field(default="Teams table retrieved successfully")
+    teams: list[TeamTableRowDTO] = Field(default_factory=list)
+
+
 class TeamTableRowDTO(BaseModel):
     team_name: str = Field(...)
     leader_name: str | None = Field(default=None)


### PR DESCRIPTION
# Task
- Portrait's Endpoint

# Solution
1. Disable roles confirmation in POST and DELETE portrait's endpoint
2. Add ListTeamsTableResponseDTO in response